### PR TITLE
Use ISO 8601 UTC in /api/status time stamps

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ SOURCEDIR=.
 SOURCES := $(shell find $(SOURCEDIR) -name '*.go')
 
 # Build configuration
-BUILD_TIME=`date -u '+%Y-%m-%d_%I:%M:%S%p'`
+BUILD_TIME=`date -u '+%Y-%m-%dT%H:%M:%SZ'`
 COMMIT=$(shell git rev-parse HEAD)
 GITUNTRACKEDCHANGES := $(shell git status --porcelain --untracked-files=no)
 ifneq ($(GITUNTRACKEDCHANGES),)


### PR DESCRIPTION
Not sure if almighty/almighty-core#332 is relevant for almighty-test-runner but just in case here is the PR to sync both Makefiles.

New layout/format of the start and build time stamps is YYYY-MM-DDThh:mm:ssZ
Example: {"build_time":"2016-10-03T23:43:19Z","commit":"6cc69c8cd782371de3eff4615eedb5b664292cb8-dirty","start_time":"2016-10-03T23:44:12Z"}

For more details about this format see https://www.w3.org/TR/NOTE-datetime
